### PR TITLE
Add +RECV event FIFO functionality

### DIFF
--- a/src/cmd.c
+++ b/src/cmd.c
@@ -1944,7 +1944,6 @@ static void get_rfpower(void)
     OK("0,%d,0,%d", r1.Param.ChannelsTxPower, r2.Param.ChannelsDefaultTxPower);
 }
 
-
 static void set_rfpower(atci_param_t *param)
 {
     uint32_t paboost1, paboost2, val1, val2;
@@ -1985,6 +1984,55 @@ static void set_rfpower(atci_param_t *param)
     r.Param.ChannelsTxPower = val1;
     abort_on_error(LoRaMacMibSetRequestConfirm(&r));
 
+    OK_();
+}
+
+
+static void get_recvlen(void)
+{
+    cmd_printf("$RECVLEN=%d\r\n", lrw_recv_len());
+    OK_();
+}
+
+static void get_recvget(void)
+{
+    lrw_recv_t *recv = lrw_recv_get();
+
+    log_debug("recvget: %p", (void *)recv);
+
+    if (recv == NULL)
+    {
+        cmd_print("$RECVGET=0,0,0\r\n");
+    } else {
+        cmd_printf("$RECVGET=%d,%d,%d,", lrw_recv_len(), recv->port, recv->length);
+        atci_print_buffer_as_hex(recv->buffer, recv->length);
+        cmd_print("\r\n");
+    }
+    OK_();
+}
+
+static void get_recvclear(void)
+{
+    lrw_recv_clear();
+    OK_();
+}
+
+static void get_recvurc(void)
+{
+    cmd_printf("$RECVURC=%d\r\n", lrw_recv_urc_get());
+    OK_();
+}
+
+static void set_recvurc(atci_param_t *param)
+{
+    uint32_t val;
+
+    if (!atci_param_get_uint(param, &val)) abort(ERR_PARAM);
+    if (val > 1) abort(ERR_PARAM);
+
+    if (param->offset != param->length) abort(ERR_PARAM_NO);
+
+    lrw_recv_urc_set(val);
     OK_();
 }
 
@@ -2357,6 +2405,10 @@ static const atci_command_t cmds[] = {
     {"$RX2",         NULL,            set_rx2,          get_rx2,          NULL, "Configure RX2 window frequency and data rate"},
     {"$DR",          NULL,            set_dr,           get_dr,           NULL, "Configure data rate (DR)"},
     {"$RFPOWER",     NULL,            set_rfpower,      get_rfpower,      NULL, "Configure RF power"},
+    {"$RECVLEN",     NULL,            NULL,             get_recvlen,      NULL, "Get number of recive messages in fifo"},
+    {"$RECVGET",     NULL,            NULL,             get_recvget,      NULL, "Get recive messages from fifo"},
+    {"$RECVCLEAR",   NULL,            NULL,             get_recvclear,    NULL, "Clear recive message fifo"},
+    {"$RECVURC",     NULL,            set_recvurc,      get_recvurc,      NULL, "Enable/Disable URC +RECV"},
 #if DEBUG_LOG != 0
     {"$LOGLEVEL",    NULL,            set_loglevel,     get_loglevel,     NULL, "Configure logging on USART port"},
 #endif

--- a/src/lrw.h
+++ b/src/lrw.h
@@ -190,16 +190,44 @@ void lrw_factory_reset(bool reset_devnonce, bool reset_deveui);
 LoRaMacStatus_t lrw_get_device_time(bool piggyback);
 
 
+/**
+ * @brief Structure for storing received data
+ */
 typedef struct {
+    // @brief Port number
     uint8_t port;
+    // @brief Received data
     uint8_t buffer[256];
+    // @brief Length of received data
     uint8_t length;
 } lrw_recv_t;
 
+
+/** @brief Return the number of received messages in FIFO
+ * @return Number of received messages
+*/
 uint8_t lrw_recv_len(void);
+
+/** @brief Return a pointer to the received message to last message FIFO
+ * @return Pointer to the received message
+*/
 lrw_recv_t *lrw_recv_get(void);
+
+/** @brief Clear the received message FIFO
+*/
 void lrw_recv_clear(void);
+
+/** @brief Enable or disable the publish of URC +RECV=
+ *
+ * This config is not persistent, it will be reset after reboot.
+ *
+ * @param[in] enable Enable or disable URC publish
+*/
 void lrw_recv_urc_set(bool enable);
+
+/** @brief Return the current config of URC +RECV=
+ * @return URC publish config
+*/
 bool lrw_recv_urc_get(void);
 
 #endif // _LRW_H

--- a/src/lrw.h
+++ b/src/lrw.h
@@ -189,4 +189,17 @@ void lrw_factory_reset(bool reset_devnonce, bool reset_deveui);
  */
 LoRaMacStatus_t lrw_get_device_time(bool piggyback);
 
+
+typedef struct {
+    uint8_t port;
+    uint8_t buffer[256];
+    uint8_t length;
+} lrw_recv_t;
+
+uint8_t lrw_recv_len(void);
+lrw_recv_t *lrw_recv_get(void);
+void lrw_recv_clear(void);
+void lrw_recv_urc_set(bool enable);
+bool lrw_recv_urc_get(void);
+
 #endif // _LRW_H

--- a/src/lrw.h
+++ b/src/lrw.h
@@ -208,8 +208,8 @@ typedef struct {
 */
 uint8_t lrw_recv_len(void);
 
-/** @brief Return a pointer to the received message to last message FIFO
- * @return Pointer to the received message
+/** @brief Return a pointer to the received message to first message FIFO
+ * @return Pointer to the first received message
 */
 lrw_recv_t *lrw_recv_get(void);
 
@@ -217,9 +217,9 @@ lrw_recv_t *lrw_recv_get(void);
 */
 void lrw_recv_clear(void);
 
-/** @brief Enable or disable the publish of URC +RECV=
+/** @brief Enable or disable asynchronous +RECV events
  *
- * This config is not persistent, it will be reset after reboot.
+ * This parameter is not persistent, it will be reset after reboot.
  *
  * @param[in] enable Enable or disable URC publish
 */


### PR DESCRIPTION
Based off of a previous PR: [ #138](https://github.com/hardwario/lora-modem/pull/138)

Fixes all feedback.
Maintains the static allocation of the fifo space.